### PR TITLE
Resolves possible error in user variable path assumptions

### DIFF
--- a/scripts/function/tools
+++ b/scripts/function/tools
@@ -4,8 +4,8 @@ GREP_ERROR="GVM couldn't find grep"
 SORT_ERROR="GVM couldn't find sort"
 HEAD_ERROR="GVM couldn't find head"
 
-LS_PATH=$(unalias ls &> /dev/null; which ls) || display_error "$LS_ERROR" || return 1
-GREP_PATH=$(unalias grep &> /dev/null; which grep) || display_error "$GREP_ERROR" || return 1
-SORT_PATH=$(unalias sort &> /dev/null; which sort) || display_error "$SORT_ERROR" || return 1
-HEAD_PATH=$(unalias head &> /dev/null; which head) || display_error "$HEAD_ERROR" || return 1
+LS_PATH=$(unalias ls &> /dev/null; command -v ls) || display_error "$LS_ERROR" || return 1
+GREP_PATH=$(unalias grep &> /dev/null; command -v grep) || display_error "$GREP_ERROR" || return 1
+SORT_PATH=$(unalias sort &> /dev/null; command -v sort) || display_error "$SORT_ERROR" || return 1
+HEAD_PATH=$(unalias head &> /dev/null; command -v head) || display_error "$HEAD_ERROR" || return 1
 


### PR DESCRIPTION
This fix removes using the system `which` command for determining the
path for the following commands:
    - ls
    - grep
    - sort
    - head

It instead will use the `command -v` builtin in order to determine the
various paths to the binary applications. Use of which leaves open
the possibility for bugs and different use cases on various systems.

For more info on why this is a bad practice see:
http://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script
